### PR TITLE
Tooling for GitHub Release Assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,12 @@ If you then run `await myDependency.ensureInstalled("remote")`, it will give you
 
 If you instead run `await myDependency.ensureInstalled("local")` (or `update`, `install`, etc.), it will simply give you back a reference to the folder at /path/to/external/local/installation, after ensuring that folder actually exists.
 
+### GitHub Assets
+
+`GitHubReleaseAsset` in the `dependencies` package provides the following two functions to retrieve the URL to download an asset for a particular GitHub release:
+- `getLatestAssetUrl(...)`: retrieves the URL to an asset of the latest GitHub pre- or non-pre-release
+- `getTaggedAssetUrl(...)`: retrieves the URL to an asset of a GitHub (pre- or non-pre-)release based on a git tag
+
+The returned URL can then, for example, be passed to `FileDownloader` to download the asset.
+
+If you use GitHub pre-releases as nightly builds of your repository, the [create-nightly-release](https://github.com/viperproject/create-nightly-release) repo provides a GitHub action that creates a pre-release and automatically deletes old pre-releases (for safety reasons only pre-releases that have been created by that action).

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,113 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@octokit/auth-token": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
+      "integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
+      "requires": {
+        "@octokit/types": "^5.0.0"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.1.2.tgz",
+      "integrity": "sha512-AInOFULmwOa7+NFi9F8DlDkm5qtZVmDQayi7TUgChE3yeIGPq0Y+6cAEXPexQ3Ea+uZy66hKEazR7DJyU+4wfw==",
+      "requires": {
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/graphql": "^4.3.1",
+        "@octokit/request": "^5.4.0",
+        "@octokit/types": "^5.0.0",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.8.tgz",
+      "integrity": "sha512-MuRrgv+bM4Q+e9uEvxAB/Kf+Sj0O2JAOBA131uo1o6lgdq1iS8ejKwtqHgdfY91V3rN9R/hdGKFiQYMzVzVBEQ==",
+      "requires": {
+        "@octokit/types": "^5.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.6.tgz",
+      "integrity": "sha512-Rry+unqKTa3svswT2ZAuqenpLrzJd+JTv89LTeVa5UM/5OX8o4KTkPL7/1ABq4f/ZkELb0XEK/2IEoYwykcLXg==",
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.4.0.tgz",
+      "integrity": "sha512-YT6Klz3LLH6/nNgi0pheJnUmTFW4kVnxGft+v8Itc41IIcjl7y1C8TatmKQBbCSuTSNFXO5pCENnqg6sjwpJhg==",
+      "requires": {
+        "@octokit/types": "^5.5.0"
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
+      "integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw=="
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.2.0.tgz",
+      "integrity": "sha512-1/qn1q1C1hGz6W/iEDm9DoyNoG/xdFDt78E3eZ5hHeUfJTLJgyAMdj9chL/cNBHjcjd+FH5aO1x0VCqR2RE0mw==",
+      "requires": {
+        "@octokit/types": "^5.5.0",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.4.9",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.9.tgz",
+      "integrity": "sha512-CzwVvRyimIM1h2n9pLVYfTDmX9m+KHSgCpqPsY8F1NdEK8IaWqXhSBXsdjOBFZSpEcxNEeg4p0UO9cQ8EnOCLA==",
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^5.0.0",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "once": "^1.4.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
+      "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+      "requires": {
+        "@octokit/types": "^5.0.1",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "18.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.0.6.tgz",
+      "integrity": "sha512-ES4lZBKPJMX/yUoQjAZiyFjei9pJ4lTTfb9k7OtYoUzKPDLl/M8jiHqt6qeSauyU4eZGLw0sgP1WiQl9FYeM5w==",
+      "requires": {
+        "@octokit/core": "^3.0.0",
+        "@octokit/plugin-paginate-rest": "^2.2.0",
+        "@octokit/plugin-request-log": "^1.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "4.2.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.5.0.tgz",
+      "integrity": "sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==",
+      "requires": {
+        "@types/node": ">= 8"
+      }
+    },
     "@sindresorhus/is": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.2.tgz",
@@ -181,6 +288,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "before-after-hook": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
     },
     "binary-extensions": {
       "version": "2.1.0",
@@ -401,6 +513,11 @@
         "object-keys": "^1.0.12"
       }
     },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -449,6 +566,7 @@
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
             "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
             "is-regex": "^1.1.1",
             "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
@@ -463,8 +581,30 @@
           "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
           "requires": {
             "define-properties": "^1.1.3",
+            "es-abstract": "^1.18.0-next.0",
             "has-symbols": "^1.0.1",
             "object-keys": "^1.1.1"
+          },
+          "dependencies": {
+            "es-abstract": {
+              "version": "1.18.0-next.1",
+              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+              "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+              "requires": {
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1",
+                "is-callable": "^1.2.2",
+                "is-negative-zero": "^2.0.0",
+                "is-regex": "^1.1.1",
+                "object-inspect": "^1.8.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.1",
+                "string.prototype.trimend": "^1.0.1",
+                "string.prototype.trimstart": "^1.0.1"
+              }
+            }
           }
         }
       }
@@ -785,11 +925,21 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-negative-zero": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE="
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
+    },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
     },
     "is-regex": {
       "version": "1.1.1",
@@ -880,6 +1030,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+    },
+    "md5-file": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-5.0.0.tgz",
+      "integrity": "sha512-xbEFXCYVWrSx/gEKS1VPlg84h/4L20znVIulKw6kMfmBUAZNAnF00eczz9ICMl+/hjQGo5KSXRxbL/47X3rmMw==",
+      "dev": true
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -986,6 +1142,11 @@
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
       }
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -1294,6 +1455,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
       "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
+    },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
     },
     "universalify": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -39,12 +39,14 @@
     "@types/glob": "^7.1.1",
     "@types/mocha": "^7.0.2",
     "glob": "^7.1.6",
+    "md5-file": "^5.0.0",
     "mocha": "^7.1.0",
     "tslint": "^6.1.0",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "@octokit/rest": "^18.0.6",
     "@types/fs-extra": "^8.1.0",
     "@types/vscode": "^1.43.0",
     "extract-zip": "^2.0.0",

--- a/src/dependencies/FileDownloader.ts
+++ b/src/dependencies/FileDownloader.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import got, { Progress } from 'got';
+import got, { Headers, Options, Progress } from 'got';
 import * as stream from 'stream';
 import { promisify } from 'util';
 
@@ -10,27 +10,49 @@ import { DependencyInstaller, Location, ProgressListener } from '..';
 const pipeline = promisify(stream.pipeline);
 
 export class FileDownloader implements DependencyInstaller {
+	/**
+	 * 
+	 * @param remoteUrl URL from which the file should be downloaded
+	 * @param headers header fields that should be used for the request. This can be used to for example set the Accept header: `{ "Accept": "application/octet-stream" }`
+	 * @param filename optional filename to store the downloaded file (default: `path.basename(remoteUrl)`, i.e. the last component of the URL)
+	 */
 	constructor(
-		readonly remoteUrl: string
+		readonly remoteUrl: string,
+		readonly headers: Headers = {},
+		readonly filename: string = path.basename(remoteUrl)
 	) { }
 
 	public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener): Promise<Location> {
-		const filename = path.basename(this.remoteUrl);
-		const target = location.child(filename);
+		const target = location.child(this.filename);
 
 		if (!shouldUpdate && await target.exists()) { return target; }
 
 		await location.mkdir();
-		const temp = location.child(`.${filename}.download`);
+		const temp = location.child(`.${this.filename}.download`);
 		await temp.unlinkIfExists();
 		const tempFile = fs.createWriteStream(temp.basePath);
 
 		try {
+			const options = {
+				headers: this.headers
+			};
 			progressListener(0, "Downloading…");
+			// if a redirect occurs, downloadProgress will immediately jump to 1 as the progress is reported per request.
+			// progressListener ignores lower progress than previously reported.
+			// as a work around, simply ignore the next progress report after a redirect has occurred. This works fairly
+			// well in practice as a redirect response is small and progress jumps from 0 to 1 (without intermediate progress).
+			let skipNextProgress: boolean = false;
 			await pipeline(
 				got
-					.stream(this.remoteUrl)
-					.on('downloadProgress', (prog: Progress) => progressListener(prog.percent, "Downloading…")),
+					.stream(this.remoteUrl, options)
+					.on('redirect', () => skipNextProgress = true)
+					.on('downloadProgress', (prog: Progress) => { 
+						if (skipNextProgress) { 
+							skipNextProgress = false; 
+						} else { 
+							progressListener(prog.percent, "Downloading…"); 
+						}
+					}),
 				tempFile
 			);
 	

--- a/src/dependencies/GitHubReleaseAsset.ts
+++ b/src/dependencies/GitHubReleaseAsset.ts
@@ -1,0 +1,91 @@
+import { Octokit } from "@octokit/rest";
+
+/**
+ * Class containing helper functions to facilitate retrieving assets from GitHub releases
+ */
+export class GitHubReleaseAsset {
+
+    /**
+     * Retrieves the URL to a particular asset in the latest release.
+     * Note that the accept header has to be set to "application/octet-stream" to download the asset.
+     * @param owner The GitHub repo owner, e.g. "viperproject"
+     * @param repo The GitHub repo, e.g. "vs-verification-toolbox"
+     * @param assetName The name of the asset (as shown in the GitHub UI for the release)
+     * @param includePrereleases Flag to indicate whether prereleases should be considered as well (by default only non-prereleases will be considered)
+     */
+    public static async getLatestAssetUrl(
+        owner: string,
+        repo: string,
+        assetName: string,
+        includePrereleases: boolean = false
+    ): Promise<string> {
+        const octokit = new Octokit();
+        let latestRelease: Release;
+        if (includePrereleases) {
+            // get the first release which corresponds to the latest pre- or non-pre-release.
+            // note that draft releases do not show up for unauthenticated users
+            // see https://octokit.github.io/rest.js/v18#repos-list-releases
+            const { data: releases } = await octokit.repos.listReleases({
+                owner,
+                repo,
+                per_page: 1,
+                page: 1
+            })
+            if (releases.length >= 1) {
+                latestRelease = releases[0];
+            } else {
+                return Promise.reject("list releases did not return any release");
+            }
+        } else {
+            // see https://octokit.github.io/rest.js/v18#repos-get-latest-release
+            const releaseResponse = await octokit.repos.getLatestRelease({
+                owner,
+                repo,
+            });
+            latestRelease = releaseResponse.data;
+        }
+        return this.getAssetUrlFromRelease(latestRelease, assetName);
+    }
+
+    /**
+     * Retrieves the URL to a particular asset in a release specified by its tag.
+     * Note that the accept header has to be set to "application/octet-stream" to download the asset.
+     * @param owner The GitHub repo owner, e.g. "viperproject"
+     * @param repo The GitHub repo, e.g. "vs-verification-toolbox"
+     * @param assetName The name of the asset (as shown in the GitHub UI for the release)
+     * @param tag Name of the git tag
+     */
+    public static async getTaggedAssetUrl(
+        owner: string,
+        repo: string,
+        assetName: string,
+        tag: string
+    ): Promise<string> {
+        const octokit = new Octokit();
+        // see https://octokit.github.io/rest.js/v18#repos-get-release-by-tag
+        const releaseResponse = await octokit.repos.getReleaseByTag({
+            owner,
+            repo,
+            tag
+        });
+        const taggedRelease = releaseResponse.data;
+        return this.getAssetUrlFromRelease(taggedRelease, assetName);
+    }
+
+    private static getAssetUrlFromRelease(release: Release, assetName: string): Promise<string> {
+        const asset = release.assets.find(asset => asset.name === assetName);
+        if (asset) {
+            return Promise.resolve(asset.url);
+        }
+        return Promise.reject(`Asset named '${assetName}' not found`);
+    }
+}
+
+interface Release {
+    assets: Asset[];
+}
+
+interface Asset {
+    name: string;
+    url: string;
+}

--- a/src/dependencies/index.ts
+++ b/src/dependencies/index.ts
@@ -1,5 +1,6 @@
 export * from './Dependency';
 export * from './FileDownloader';
+export * from './GitHubReleaseAsset';
 export * from './ZipExtractor';
 export * from './InstallerSequence';
 export * from './LocalReference';

--- a/src/test/dependencies.test.ts
+++ b/src/test/dependencies.test.ts
@@ -1,18 +1,21 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as assert from 'assert';
+import * as md5File from 'md5-file';
 
 import { Dependency, FileDownloader, InstallerSequence, LocalReference, ZipExtractor } from '..';
 import { withProgressInWindow } from '../util';
+import { GitHubReleaseAsset } from '../dependencies';
 
 suite("dependencies", () => {
 
     const PROJECT_ROOT = path.join(__dirname, "../../");
     const TMP_PATH: string = path.join(PROJECT_ROOT, "src", "test", "tmp");
     const HTTP_DOWNLOAD_URL: string = "http://viper.ethz.ch/examples/";
-    const HTTP_DOWNLOAD_TIMEOUT_MS: number = 10 * 1000;
+    const HTTP_DOWNLOAD_TIMEOUT_MS: number = 10 * 1000; // 10s
     const HTTPS_DOWNLOAD_URL: string = "https://ethz.ch";
-    const HTTPS_DOWNLOAD_TIMEOUT_MS: number = 10 * 1000;
+    const HTTPS_DOWNLOAD_TIMEOUT_MS: number = 10 * 1000; // 10s
+    const PRUSTI_UBUNTU_ASSET_DOWNLOAD_TIMEOUT_MS: number = 3 * 60 * 1000; // 3min
 
     suiteSetup(function() {
         // create a tmp directory for downloading files to it
@@ -63,6 +66,47 @@ suite("dependencies", () => {
         return withProgressInWindow(
             "Testing download of an HTTP file",
             listener => myDependency.install("remote", true, listener));
+    });
+
+    test("Get tagged asset url", async function() {
+        this.timeout(PRUSTI_UBUNTU_ASSET_DOWNLOAD_TIMEOUT_MS);
+        const assetName = "prusti-release-ubuntu.zip";
+        const url = await GitHubReleaseAsset.getTaggedAssetUrl(
+            "viperproject", "prusti-dev", assetName, "v-2020-10-06-1807");
+        console.info(`URL to prusti-dev Ubuntu asset of v-2020-10-06-1807 release: '${url}'`);
+
+        // now download the zip:
+        const headers = {
+            "Accept": "application/octet-stream"
+        };
+        const myDependency = new Dependency<"remote">(
+            TMP_PATH,
+            ["remote",
+                new InstallerSequence([
+                    new FileDownloader(url, headers, assetName)
+                ])
+            ]
+        );
+        const { result: downloadDestination } = await withProgressInWindow(
+            "Testing download of a GitHub asset",
+            listener => myDependency.install("remote", true, listener));
+        console.log(`Prusti asset downloaded to '${downloadDestination.basePath}'`);
+        // check md5 of this file
+        const expected: string = "f7d4dd24eb40c0375d7a37d839ca515b";
+        const actual: string = await md5File(downloadDestination.basePath);
+        assert.strictEqual(actual, expected, `md5 hash of downloaded Prusti release asset does not match`);
+    });
+
+    test("Get latest pre-release asset url", async function() {
+        const url = await GitHubReleaseAsset.getLatestAssetUrl(
+            "viperproject", "prusti-dev", "prusti-release-ubuntu.zip", /* includePrerelease */ true);
+        console.info(`URL to latest non-pre- or pre-release prusti-dev Ubuntu asset is: '${url}'`);
+    });
+
+    test("Get latest asset url", async function() {
+        const url = await GitHubReleaseAsset.getLatestAssetUrl(
+            "viperproject", "prusti-dev", "prusti-release-ubuntu.zip");
+        console.info(`URL to latest non-pre-release prusti-dev Ubuntu asset is: '${url}'`);
     });
 
     suiteTeardown(function() {


### PR DESCRIPTION
This PR adds helper functions to retrieve the download URL for assets of a GitHub release. Supported are the latest non-prerelease, the latest pre- or non-prerelease, as well as a release based on its git tag.

Furthermore, the following improvements are part of this PR:
- Request header can optionally be set in `FileDownloader`
- A destination filename can optionally be set in `FileDownloader`
- Fixes progress reporting for downloads that involve redirects