### PR TITLE
Enables Authenticated GitHub API Access

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,4 +40,4 @@ jobs:
         with:
           run: npm test
         env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,5 @@ jobs:
         uses: GabrielBB/xvfb-action@v1.0
         with:
           run: npm test
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -222,6 +222,21 @@
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.49.0.tgz",
       "integrity": "sha512-wfNQmLmm1VdMBr6iuNdprWmC1YdrgZ9dQzadv+l2eSjJlElOdJw8OTm4RU4oGTBcfvG6RZI2jOcppkdSS18mZw=="
     },
+    "@types/yargs": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
+      "integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
+      "dev": true
+    },
     "@types/yauzl": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
@@ -399,40 +414,46 @@
       }
     },
     "cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.1.tgz",
+      "integrity": "sha512-rcvHOWyGyid6I1WjT/3NatKj2kDt9OdSHSXpyLXaMWFbKpGACNW8pRhhdPUq9MWUOdwn8Rz9AVETjF4105rZZQ==",
       "dev": true,
       "requires": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
         "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.0"
           }
         }
       }
@@ -525,9 +546,9 @@
       "dev": true
     },
     "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "end-of-stream": {
@@ -631,6 +652,12 @@
       "requires": {
         "es6-promise": "^4.0.3"
       }
+    },
+    "escalade": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
+      "integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1097,6 +1124,23 @@
         "yargs-unparser": "1.6.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -1105,6 +1149,12 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
         },
         "glob": {
           "version": "7.1.3",
@@ -1125,6 +1175,61 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
         }
       }
     },
@@ -1501,40 +1606,70 @@
       }
     },
     "wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
         "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.0"
           }
         }
       }
@@ -1545,54 +1680,63 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.2.tgz",
+      "integrity": "sha512-CkwaeZw6dQgqgPGeTWKMXCRmMcBgETFlTml1+ZOO+q7kGst8NREJ+eWwFNPVUQ4QGdAaklbqCZHH6Zuep1RjiA==",
       "dev": true
     },
     "yargs": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-6+nLw8xa9uK1BOEOykaiYAJVh6/CjxWXK/q9b5FpRgNslt8s22F2xMBqVIKgCRjNgGvGPBy8Vog7WN7yh4amtA==",
       "dev": true,
       "requires": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
+        "cliui": "^7.0.0",
+        "escalade": "^3.0.2",
+        "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.1",
+        "yargs-parser": "^20.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
         },
         "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.0"
           }
+        },
+        "yargs-parser": {
+          "version": "20.2.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.1.tgz",
+          "integrity": "sha512-yYsjuSkjbLMBp16eaOt7/siKTjNVjMm3SoJnIg3sEh/JsvqVVDyjRKmaJV4cl+lNIgq6QEco2i3gDebJl7/vLA==",
+          "dev": true
         }
       }
     },
@@ -1615,6 +1759,86 @@
         "flat": "^4.1.0",
         "lodash": "^4.17.15",
         "yargs": "^13.3.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        }
       }
     },
     "yauzl": {

--- a/package.json
+++ b/package.json
@@ -38,12 +38,14 @@
   "devDependencies": {
     "@types/glob": "^7.1.1",
     "@types/mocha": "^7.0.2",
+    "@types/yargs": "^15.0.8",
     "glob": "^7.1.6",
     "md5-file": "^5.0.0",
     "mocha": "^7.1.0",
     "tslint": "^6.1.0",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^3.8.3"
+    "typescript": "^3.8.3",
+    "yargs": "^16.0.3"
   },
   "dependencies": {
     "@octokit/rest": "^18.0.6",

--- a/src/dependencies/GitHubReleaseAsset.ts
+++ b/src/dependencies/GitHubReleaseAsset.ts
@@ -22,7 +22,7 @@ export class GitHubReleaseAsset {
         includePrereleases: boolean = false,
         token?: string
     ): Promise<string> {
-        const octokit = this.getOctokit(token);
+        const octokit = this.buildOctokit(token);
         let latestRelease: Release;
         if (includePrereleases) {
             // get the first release which corresponds to the latest pre- or non-pre-release.
@@ -72,7 +72,7 @@ export class GitHubReleaseAsset {
         tag: string,
         token?: string
     ): Promise<string> {
-        const octokit = this.getOctokit(token);
+        const octokit = this.buildOctokit(token);
         // see https://octokit.github.io/rest.js/v18#repos-get-release-by-tag
         const releaseResponse = await octokit.repos.getReleaseByTag({
             owner,
@@ -87,7 +87,7 @@ export class GitHubReleaseAsset {
      * Returns an octokit instance that optionally uses the token for authentiction
      * @param token personal access token, OAuth token, installation access token, or JSON Web Token for GitHub App authentication
      */
-    private static getOctokit(token?: string): Octokit {
+    private static buildOctokit(token?: string): Octokit {
         if (token) {
             return new Octokit({
                 auth: token,

--- a/src/dependencies/GitHubReleaseAsset.ts
+++ b/src/dependencies/GitHubReleaseAsset.ts
@@ -8,6 +8,7 @@ export class GitHubReleaseAsset {
     /**
      * Retrieves the URL to a particular asset in the latest release.
      * Note that the accept header has to be set to "application/octet-stream" to download the asset.
+     * If you want to use the token for the download as well, you have to add the following header: "Authorization: token <token>".
      * @param owner The GitHub repo owner, e.g. "viperproject"
      * @param repo The GitHub repo, e.g. "vs-verification-toolbox"
      * @param assetName The name of the asset (as shown in the GitHub UI for the release)
@@ -57,6 +58,7 @@ export class GitHubReleaseAsset {
     /**
      * Retrieves the URL to a particular asset in a release specified by its tag.
      * Note that the accept header has to be set to "application/octet-stream" to download the asset.
+     * If you want to use the token for the download as well, you have to add the following header: "Authorization: token <token>".
      * @param owner The GitHub repo owner, e.g. "viperproject"
      * @param repo The GitHub repo, e.g. "vs-verification-toolbox"
      * @param assetName The name of the asset (as shown in the GitHub UI for the release)

--- a/src/dependencies/GitHubZipExtractor.ts
+++ b/src/dependencies/GitHubZipExtractor.ts
@@ -1,0 +1,45 @@
+import * as path from 'path';
+
+import { DependencyInstaller, Location, ProgressListener, InstallerSequence, FileDownloader, ZipExtractor } from '..';
+
+/**
+ * Extension of RemoteZipExtractor with the following features:
+ * - no remote URL needed at construction time: a (potentially expensive) computation of the remote URL is only 
+ *   performed when a download will actually take place.
+ * - the correct header for downloading a GitHub release asset is set
+ * - if a GitHub token is provided it is used to perform the download as an authenticated user
+ */
+export class GitHubZipExtractor implements DependencyInstaller {
+    private sequence: InstallerSequence | undefined;
+
+    constructor(
+        readonly remoteUrlFn: () => Promise<string>,
+        readonly folderName: string, // non optional as we need to determine whether a download is necessary
+        readonly token?: string
+    ) { }
+
+    public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener): Promise<Location> {
+        const target = location.child(this.folderName);
+
+        if (!shouldUpdate && await target.exists()) { return target; }
+
+        if (this.sequence == null) {
+            const remoteUrl = await this.remoteUrlFn();
+
+            const downloadHeaders: Record<string, string | string[] | undefined> = {
+                "Accept": "application/octet-stream"
+            };
+            if (this.token) {
+                downloadHeaders["Authorization"] = `token ${this.token}`;
+            }
+
+            // lazily initialize sequence:
+            this.sequence = new InstallerSequence([
+                new FileDownloader(remoteUrl, downloadHeaders),
+                new ZipExtractor(this.folderName, true),
+            ]);
+        }
+
+        return this.sequence.install(location, shouldUpdate, progressListener);
+    }
+}

--- a/src/dependencies/GitHubZipExtractor.ts
+++ b/src/dependencies/GitHubZipExtractor.ts
@@ -13,9 +13,9 @@ export class GitHubZipExtractor implements DependencyInstaller {
     private sequence: InstallerSequence | undefined;
 
     constructor(
-        readonly remoteUrlFn: () => Promise<string>,
-        readonly folderName: string, // non optional as we need to determine whether a download is necessary
-        readonly token?: string
+        private readonly remoteUrlFn: () => Promise<string>,
+        private readonly folderName: string, // non optional as we need to determine whether a download is necessary
+        private readonly token?: string
     ) { }
 
     public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener): Promise<Location> {

--- a/src/dependencies/index.ts
+++ b/src/dependencies/index.ts
@@ -1,6 +1,7 @@
 export * from './Dependency';
 export * from './FileDownloader';
 export * from './GitHubReleaseAsset';
+export * from './GitHubZipExtractor';
 export * from './ZipExtractor';
 export * from './InstallerSequence';
 export * from './LocalReference';

--- a/src/test/dependencies.test.ts
+++ b/src/test/dependencies.test.ts
@@ -78,7 +78,7 @@ suite("dependencies", () => {
         const tag = "v1.1";
         const md5Hash = "a0948bb73029668fec22741c38b611ef";
         const url = await GitHubReleaseAsset.getTaggedAssetUrl(
-            ASSET_OWNER, ASSET_REPO, assetName, tag);
+            ASSET_OWNER, ASSET_REPO, assetName, tag, getToken());
         await downloadAndCheckGitHubAsset(url, assetName, md5Hash);
     });
 
@@ -88,7 +88,7 @@ suite("dependencies", () => {
         const tag = "v1";
         const md5Hash = "7dcd4caa25bceaabdb2ca525377fab0b";
         const url = await GitHubReleaseAsset.getTaggedAssetUrl(
-            ASSET_OWNER, ASSET_REPO, assetName, tag);
+            ASSET_OWNER, ASSET_REPO, assetName, tag, getToken());
         await downloadAndCheckGitHubAsset(url, assetName, md5Hash);
     });
 
@@ -98,7 +98,7 @@ suite("dependencies", () => {
         // latest prerelease is v1.2
         const md5Hash = "d1b9d86a9ea97fa0d2f9dd32ac99ea57";
         const url = await GitHubReleaseAsset.getLatestAssetUrl(
-            ASSET_OWNER, ASSET_REPO, assetName, /* includePrerelease */ true);
+            ASSET_OWNER, ASSET_REPO, assetName, /* includePrerelease */ true, getToken());
         await downloadAndCheckGitHubAsset(url, assetName, md5Hash);
     });
 
@@ -108,7 +108,7 @@ suite("dependencies", () => {
         // latest prerelease is v1.2
         const md5Hash = "aaf83dc77a9fe4e0379476e3d16940f6";
         const url = await GitHubReleaseAsset.getLatestAssetUrl(
-            ASSET_OWNER, ASSET_REPO, assetName, /* includePrerelease */ true);
+            ASSET_OWNER, ASSET_REPO, assetName, /* includePrerelease */ true, getToken());
         await downloadAndCheckGitHubAsset(url, assetName, md5Hash);
     });
 
@@ -118,7 +118,7 @@ suite("dependencies", () => {
         // latest non-pre-release is v1
         const md5Hash = "1c9e58ecee1520efcabee1525f858637";
         const url = await GitHubReleaseAsset.getLatestAssetUrl(
-            ASSET_OWNER, ASSET_REPO, assetName);
+            ASSET_OWNER, ASSET_REPO, assetName, false, getToken());
         await downloadAndCheckGitHubAsset(url, assetName, md5Hash);
     });
 
@@ -128,14 +128,22 @@ suite("dependencies", () => {
         // latest non-pre-release is v1
         const md5Hash = "c3163d654efcc01ff707c3a938764040";
         const url = await GitHubReleaseAsset.getLatestAssetUrl(
-            ASSET_OWNER, ASSET_REPO, assetName);
+            ASSET_OWNER, ASSET_REPO, assetName, false, getToken());
         await downloadAndCheckGitHubAsset(url, assetName, md5Hash);
     });
 
+    function getToken(): string | undefined {
+        return process.env["TOKEN"];
+    }
+
     async function downloadAndCheckGitHubAsset(url: string, assetName: string, md5Hash: string): Promise<void> {
-        const headers = {
+        const headers: Record<string, string | string[] | undefined> = {
             "Accept": "application/octet-stream"
         };
+        const token = getToken();
+        if (token) {
+            headers["Authorization"] = `token ${token}`;
+        }
         const myDependency = new Dependency<"remote">(
             TMP_PATH,
             ["remote",

--- a/src/test/dependencies.test.ts
+++ b/src/test/dependencies.test.ts
@@ -158,7 +158,7 @@ suite("dependencies", () => {
     });
 
     function getToken(): string | undefined {
-        return process.env["TOKEN"];
+        return process.env["GITHUB_TOKEN"];
     }
 
     async function downloadAndCheckGitHubAsset(url: string, assetName: string, md5Hash: string): Promise<void> {

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,9 +1,26 @@
 import * as path from 'path';
-
+import * as yargs from 'yargs';
 import { runTests } from 'vscode-test';
 
 async function main() {
     try {
+        const argv = yargs
+            .option('token', {
+                description: 'GitHub access token that should be used for GitHub API calls. '
+                    + 'Use the "TOKEN" environment variable for CI as node logs the command incl. arguments',
+                type: 'string',
+            })
+            .help() // show help if `--help` is used
+            .argv;
+
+        let extensionTestsEnv;
+        if (argv.token || process.env["TOKEN"]) {
+            // pass token as environment variable to the extension test:
+            extensionTestsEnv = {
+                "TOKEN": argv.token || process.env["TOKEN"],
+            };
+        }
+
         // The folder containing the Extension Manifest package.json
         // Passed to `--extensionDevelopmentPath`
         const extensionDevelopmentPath = path.resolve(__dirname, '../../');
@@ -11,9 +28,15 @@ async function main() {
         // The path to test runner
         // Passed to --extensionTestsPath
         const extensionTestsPath = path.resolve(__dirname, './index');
-
+        
+        const testOption = {
+            extensionDevelopmentPath: extensionDevelopmentPath,
+            extensionTestsPath: extensionTestsPath,
+            extensionTestsEnv: extensionTestsEnv,
+        };
+        
         // Download VS Code, unzip it and run the integration test
-        await runTests({ extensionDevelopmentPath, extensionTestsPath });
+        await runTests(testOption);
     } catch (err) {
         console.error('Failed to run tests');
         process.exit(1);

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -16,7 +16,6 @@ async function main() {
         let extensionTestsEnv;
         if (argv.token || process.env["TOKEN"]) {
             // pass token as environment variable to the extension test:
-            console.log("GitHub token passed as argument or env variable");
             extensionTestsEnv = {
                 "TOKEN": argv.token || process.env["TOKEN"],
             };
@@ -35,7 +34,7 @@ async function main() {
             extensionTestsPath: extensionTestsPath,
             extensionTestsEnv: extensionTestsEnv,
         };
-
+        
         // Download VS Code, unzip it and run the integration test
         await runTests(testOption);
     } catch (err) {

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -7,17 +7,17 @@ async function main() {
         const argv = yargs
             .option('token', {
                 description: 'GitHub access token that should be used for GitHub API calls. '
-                    + 'Use the "TOKEN" environment variable for CI as node logs the command incl. arguments',
+                    + 'Use the "GITHUB_TOKEN" environment variable for CI as node logs the command incl. arguments',
                 type: 'string',
             })
             .help() // show help if `--help` is used
             .argv;
 
         let extensionTestsEnv;
-        if (argv.token || process.env["TOKEN"]) {
+        if (argv.token || process.env["GITHUB_TOKEN"]) {
             // pass token as environment variable to the extension test:
             extensionTestsEnv = {
-                "TOKEN": argv.token || process.env["TOKEN"],
+                "GITHUB_TOKEN": argv.token || process.env["GITHUB_TOKEN"],
             };
         }
 

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -16,6 +16,7 @@ async function main() {
         let extensionTestsEnv;
         if (argv.token || process.env["TOKEN"]) {
             // pass token as environment variable to the extension test:
+            console.log("GitHub token passed as argument or env variable");
             extensionTestsEnv = {
                 "TOKEN": argv.token || process.env["TOKEN"],
             };
@@ -34,7 +35,7 @@ async function main() {
             extensionTestsPath: extensionTestsPath,
             extensionTestsEnv: extensionTestsEnv,
         };
-        
+
         // Download VS Code, unzip it and run the integration test
         await runTests(testOption);
     } catch (err) {


### PR DESCRIPTION
The functions to retrieve a GitHub release asset have been extended such that an optional token can be passed to them such that an authenticated API access will be performed. This increases the rate limit as only 60 requests per hour an IP address can be made unauthenticated.

In addition, this PR extends the tests to perform these API accesses as well as the asset downloads themselves authenticated using the runner's token.

Last but not least, `GitHubZipExtractor` further simplifies downloading of GitHub assets as it sets the correct download headers and only calculates the download URL when a download will actually happen