### PR TITLE
Retry in case removing a path fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: NPM Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches: 'master'
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: 'master'
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,6 @@
 name: NPM Tests
 
-on:
-  push:
-    branches: ["*"]
-  pull_request:
-    branches: ["*"]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/src/dependencies/FileDownloader.ts
+++ b/src/dependencies/FileDownloader.ts
@@ -29,7 +29,7 @@ export class FileDownloader implements DependencyInstaller {
 
 		await location.mkdir();
 		const temp = location.child(`.${this.filename}.download`);
-		await temp.unlinkIfExists();
+		await temp.remove();
 		const tempFile = fs.createWriteStream(temp.basePath);
 
 		try {
@@ -56,12 +56,12 @@ export class FileDownloader implements DependencyInstaller {
 				tempFile
 			);
 	
-			await target.unlinkIfExists();
+			await target.remove();
 			await fs.move(temp.basePath, target.basePath);
 
 			return target;
 		} catch (e) {
-			await temp.unlinkIfExists();
+			await temp.remove();
 			throw e;
 		}
 	}

--- a/src/dependencies/ZipExtractor.ts
+++ b/src/dependencies/ZipExtractor.ts
@@ -35,7 +35,7 @@ export class ZipExtractor implements DependencyInstaller {
 
 			// we don't usually delete the original zip since that would cause it to get re-downloaded on next install
 			if (this.deleteZip) {
-				fs.unlink(location.basePath);
+				location.remove()
 			}
 
 			return target;

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -28,13 +28,15 @@ async function main() {
         // The path to test runner
         // Passed to --extensionTestsPath
         const extensionTestsPath = path.resolve(__dirname, './index');
-        
+
         const testOption = {
             extensionDevelopmentPath: extensionDevelopmentPath,
             extensionTestsPath: extensionTestsPath,
             extensionTestsEnv: extensionTestsEnv,
+            // Disable any other extension
+            launchArgs: ["--disable-extensions"],
         };
-        
+
         // Download VS Code, unzip it and run the integration test
         await runTests(testOption);
     } catch (err) {


### PR DESCRIPTION
I have a case in which the file to be deleted is an executable whose process was killed, but the OS believes is still in use.