### PR TITLE
Confirmation for Installing Dependencies

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,10 @@
                 "--extensionDevelopmentPath=${workspaceFolder}",
                 "--extensionTestsPath=${workspaceFolder}/out/test",
             ],
+            "preLaunchTask": {
+                "type": "npm",
+                "script": "pretest"
+            },
             "outFiles": [
                 "${workspaceFolder}/out/test/**/*.js"
             ],

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Both functions optionally take a progress listener to report any progress and a 
 The latter is meant to ask the user for consent before actually downloading and installing anything.
 The `confirm` function is invoked before downloading or unzipping anything.
 In particular, it is not invoked when (1) the dependencies are already installed and an update is not forced or (2) the source is a local reference.
-The `confirm` function returns a promise that should be resolved when it's okay to continue with the installation and should be rejected if the installation should be aborted.
+The `confirm` function returns a promise that should be resolved with `ConfirmResult.Continue` when it's okay to continue with the installation and should be resolved with `ConfirmResult.Cancel` if the installation should be aborted.
 
 If you instead run `await myDependency.ensureInstalled("local")` (or `update`, `install`, etc.), it will simply give you back a reference to the folder at /path/to/external/local/installation, after ensuring that folder actually exists.
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ const myDependency = new Dependency<"remote" | "local">(
 This defines a dependency with two sources (`remote` and `local`) which is installed within a folder named `myDependency` within the global storage folder VS Code provides to your extension, e.g. `~/Library/Application Support/Code/User/globalStorage/<your extension slug>/myDependency`. Of course, you could specify any old path, but this one is probably a good choice for your use case.
 
 If you then run `await myDependency.ensureInstalled("remote")`, it will give you a `Location` referencing the location of the local installation from the `remote` source. If it's already installed, it won't do any extra work; otherwise it will download the file at https://remote.com/file.zip and unzip it into a folder named `unzipped`. Either way, you get back the location of the `unzipped` folder. You can force a reinstall even if it already exists by calling `update` instead of `ensureInstalled`.
+Both functions optionally take a progress listener to report any progress and a `confirm` function as arguments.
+The latter is meant to ask the user for consent before actually downloading and installing anything.
+The `confirm` function is invoked before downloading or unzipping anything.
+In particular, it is not invoked when (1) the dependencies are already installed and an update is not forced or (2) the source is a local reference.
+The `confirm` function returns a promise that should be resolved when it's okay to continue with the installation and should be rejected if the installation should be aborted.
 
 If you instead run `await myDependency.ensureInstalled("local")` (or `update`, `install`, etc.), it will simply give you back a reference to the folder at /path/to/external/local/installation, after ensuring that folder actually exists.
 

--- a/src/dependencies/Dependency.ts
+++ b/src/dependencies/Dependency.ts
@@ -19,8 +19,8 @@ export class Dependency<SourceName extends string> {
 	 * Ensures that the dependency from the given source is currently installed.
 	 * If it's not yet installed, this method will install it, otherwise it won't do anything (except provide a way to access it).
 	 */
-	public ensureInstalled(sourceName: SourceName, progressListener?: ProgressListener): Promise<Location> {
-		return this.install(sourceName, false, progressListener);
+	public ensureInstalled(sourceName: SourceName, progressListener?: ProgressListener, confirm?:() => Promise<void>): Promise<Location> {
+		return this.install(sourceName, false, progressListener, confirm);
 	}
 
 	/**
@@ -34,7 +34,7 @@ export class Dependency<SourceName extends string> {
 	 * Ensures that the dependency from the given source is currently installed.
 	 * This method is the combination of `ensureInstalled` and `update`, switching between the two based on `shouldUpdate`.
 	 */
-	public async install(sourceName: SourceName, shouldUpdate: boolean, progressListener?: ProgressListener): Promise<Location> {
+	public async install(sourceName: SourceName, shouldUpdate: boolean, progressListener?: ProgressListener, confirm?:() => Promise<void>): Promise<Location> {
 		const source = this.sources.get(sourceName);
 		if (source === undefined) {
 			throw new Error(`Dependency ${this.basePath} has no source named ${sourceName}`);
@@ -45,7 +45,8 @@ export class Dependency<SourceName extends string> {
 
 		return source.install(
 			local, shouldUpdate,
-			progressListener ?? ((_fraction, _step) => { /* do nothing */ })
+			progressListener ?? ((_fraction, _step) => { /* do nothing */ }),
+			confirm ?? (() => Promise.resolve()) // auto accept installation
 		);
 	}
 
@@ -61,6 +62,7 @@ export interface DependencyInstaller {
 	 * @param location a suggested place to install to.
 	 * @param shouldUpdate whether or not to rerun the installation process even if it is already installed, effectively updating.
 	 * @param progressListener a callback to report installation progress to, for e.g. a progress bar.
+	 * @param confirm a callback to ask a user for permission before anything is installed (this callback is not invoked if it's already installed and `shouldUpdate` is false)
 	 */
-	install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener): Promise<Location>;
+	install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener, confirm:() => Promise<void>): Promise<Location>;
 }

--- a/src/dependencies/FileDownloader.ts
+++ b/src/dependencies/FileDownloader.ts
@@ -22,10 +22,13 @@ export class FileDownloader implements DependencyInstaller {
 		readonly filename: string = path.basename(remoteUrl)
 	) { }
 
-	public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener): Promise<Location> {
+	public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener, confirm:() => Promise<void>): Promise<Location> {
 		const target = location.child(this.filename);
 
 		if (!shouldUpdate && await target.exists()) { return target; }
+
+		// ask for confirmation:
+		await confirm();
 
 		await location.mkdir();
 		const temp = location.child(`.${this.filename}.download`);

--- a/src/dependencies/GitHubZipExtractor.ts
+++ b/src/dependencies/GitHubZipExtractor.ts
@@ -18,10 +18,12 @@ export class GitHubZipExtractor implements DependencyInstaller {
         private readonly token?: string
     ) { }
 
-    public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener): Promise<Location> {
+    public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener, confirm:() => Promise<void>): Promise<Location> {
         const target = location.child(this.folderName);
 
         if (!shouldUpdate && await target.exists()) { return target; }
+
+        // we do not ask here for confirmation but defer that to the InstallerSequence
 
         if (this.sequence == null) {
             const remoteUrl = await this.remoteUrlFn();
@@ -40,6 +42,6 @@ export class GitHubZipExtractor implements DependencyInstaller {
             ]);
         }
 
-        return this.sequence.install(location, shouldUpdate, progressListener);
+        return this.sequence.install(location, shouldUpdate, progressListener, confirm);
     }
 }

--- a/src/dependencies/GitHubZipExtractor.ts
+++ b/src/dependencies/GitHubZipExtractor.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 
-import { DependencyInstaller, Location, ProgressListener, InstallerSequence, FileDownloader, ZipExtractor } from '..';
+import { ConfirmResult, DependencyInstaller, FileDownloader, InstallerSequence, InstallResult, Location, ProgressListener, Success, ZipExtractor } from '..';
 
 /**
  * Extension of RemoteZipExtractor with the following features:
@@ -18,10 +18,10 @@ export class GitHubZipExtractor implements DependencyInstaller {
         private readonly token?: string
     ) { }
 
-    public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener, confirm:() => Promise<void>): Promise<Location> {
+    public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener, confirm:() => Promise<ConfirmResult>): Promise<InstallResult<Location>> {
         const target = location.child(this.folderName);
 
-        if (!shouldUpdate && await target.exists()) { return target; }
+        if (!shouldUpdate && await target.exists()) { return new Success(target); }
 
         // we do not ask here for confirmation but defer that to the InstallerSequence
 

--- a/src/dependencies/InstallResult.ts
+++ b/src/dependencies/InstallResult.ts
@@ -1,0 +1,37 @@
+export interface InstallResult<T> {
+	isSuccess(): boolean
+}
+
+export class Success<T> implements InstallResult<T> {
+	/** non-null */
+	private readonly _value: T;
+
+	/**
+ 	 * @param t non-null
+ 	 */
+	constructor(t: T) {
+		if (t == null) {
+			throw new Error(`Invalid argument: Success(v) can only be constructed with a non-null value`);
+		}
+		this._value = t;
+	}
+
+	public get value(): T {
+		return this._value;
+	}
+
+	public isSuccess(): boolean {
+		return true;
+	}
+}
+
+export class Canceled<T> implements InstallResult<T> {
+	public isSuccess(): boolean {
+		return false;
+	}
+}
+
+export enum ConfirmResult {
+	Cancel = 0,
+	Continue,
+}

--- a/src/dependencies/InstallerSequence.ts
+++ b/src/dependencies/InstallerSequence.ts
@@ -13,16 +13,28 @@ export class InstallerSequence {
 		}, []);
 	}
 
-	public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener): Promise<Location> {
+	public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener, confirm:() => Promise<void>): Promise<Location> {
 		let index = 0;
+		let askedForConfirmation = false;
 		const total = this.installers.length;
 		for (const installer of this.installers) {
-			location = await installer.install(location, shouldUpdate, (fraction, message) => {
+			function intermediateListener(fraction: number, message: string) {
 				progressListener(
 					(index + fraction) / total,
 					`${message} (step ${index + 1} of ${total})`
 				);
-			});
+			}
+			function intermediateConfirm(): Promise<void> {
+				// only ask once
+				if (askedForConfirmation) {
+					return Promise.resolve();
+				} else {
+					askedForConfirmation = true;
+					return confirm();
+				}
+			}
+
+			location = await installer.install(location, shouldUpdate, intermediateListener, intermediateConfirm);
 			index++;
 		}
 		return location;

--- a/src/dependencies/LocalReference.ts
+++ b/src/dependencies/LocalReference.ts
@@ -7,7 +7,7 @@ export class LocalReference implements DependencyInstaller {
 		readonly referencePath: string
 	) { }
 
-	public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener): Promise<Location> {
+	public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener, confirm:() => Promise<void>): Promise<Location> {
 		if (!await fs.pathExists(this.referencePath)) {
 			throw new Error(`Can't create a local reference to the nonexistent location ${this.referencePath}`);
 		}

--- a/src/dependencies/LocalReference.ts
+++ b/src/dependencies/LocalReference.ts
@@ -1,16 +1,16 @@
 import * as fs from 'fs-extra';
 
-import { DependencyInstaller, Location, ProgressListener } from '..';
+import { ConfirmResult, DependencyInstaller, Location, InstallResult, ProgressListener, Success } from '..';
 
 export class LocalReference implements DependencyInstaller {
 	constructor(
 		readonly referencePath: string
 	) { }
 
-	public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener, confirm:() => Promise<void>): Promise<Location> {
+	public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener, confirm:() => Promise<ConfirmResult>): Promise<InstallResult<Location>> {
 		if (!await fs.pathExists(this.referencePath)) {
 			throw new Error(`Can't create a local reference to the nonexistent location ${this.referencePath}`);
 		}
-		return new Location(this.referencePath);
+		return new Success(new Location(this.referencePath));
 	}
 }

--- a/src/dependencies/RemoteZipExtractor.ts
+++ b/src/dependencies/RemoteZipExtractor.ts
@@ -15,11 +15,13 @@ export class RemoteZipExtractor implements DependencyInstaller {
         ]);
     }
 
-    public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener): Promise<Location> {
+    public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener, confirm:() => Promise<void>): Promise<Location> {
         const target = location.child(this.folderName);
 
         if (!shouldUpdate && await target.exists()) { return target; }
 
-        return this.sequence.install(location, shouldUpdate, progressListener);
+        // we do not ask here for confirmation but defer that to the InstallerSequence
+
+        return this.sequence.install(location, shouldUpdate, progressListener, confirm);
     }
 }

--- a/src/dependencies/RemoteZipExtractor.ts
+++ b/src/dependencies/RemoteZipExtractor.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 
-import { DependencyInstaller, Location, ProgressListener, InstallerSequence, FileDownloader, ZipExtractor } from '..';
+import { ConfirmResult, DependencyInstaller, FileDownloader, Location, InstallerSequence, InstallResult, ProgressListener, Success, ZipExtractor } from '..';
 
 export class RemoteZipExtractor implements DependencyInstaller {
     private readonly sequence: InstallerSequence;
@@ -15,10 +15,10 @@ export class RemoteZipExtractor implements DependencyInstaller {
         ]);
     }
 
-    public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener, confirm:() => Promise<void>): Promise<Location> {
+    public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener, confirm:() => Promise<ConfirmResult>): Promise<InstallResult<Location>> {
         const target = location.child(this.folderName);
 
-        if (!shouldUpdate && await target.exists()) { return target; }
+        if (!shouldUpdate && await target.exists()) { return new Success(target); }
 
         // we do not ask here for confirmation but defer that to the InstallerSequence
 

--- a/src/dependencies/ZipExtractor.ts
+++ b/src/dependencies/ZipExtractor.ts
@@ -10,9 +10,12 @@ export class ZipExtractor implements DependencyInstaller {
 		readonly deleteZip: boolean = false
 	) { }
 
-	public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener): Promise<Location> {
+	public async install(location: Location, shouldUpdate: boolean, progressListener: ProgressListener, confirm:() => Promise<void>): Promise<Location> {
 		const target = location.enclosingFolder.child(this.targetName);
 		if (!shouldUpdate && await target.exists()) { return target; }
+
+		// ask for confirmation:
+		await confirm();
 
 		try {
 			await target.mkdir();

--- a/src/dependencies/index.ts
+++ b/src/dependencies/index.ts
@@ -4,5 +4,6 @@ export * from './GitHubReleaseAsset';
 export * from './GitHubZipExtractor';
 export * from './ZipExtractor';
 export * from './InstallerSequence';
+export * from './InstallResult';
 export * from './LocalReference';
 export * from './RemoteZipExtractor';


### PR DESCRIPTION
Adds an optional `confirm` callback that allows to ask the user for consent in case installing a dependency results in a download or unzip operation